### PR TITLE
create CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,51 @@
+- [Package management](#package-management)
+- [High level technical overview](#high-level-technical-overview)
+
+# Package management
+
+This repo is a monorepo managed as a
+[`pnpm` Workspace](https://pnpm.io/workspaces).
+
+`pnpm` is a modern package manager that includes tools that make it easy to
+manage a monorepo.
+
+- To install packages: `pnpm i`
+- To add a package: `pnpm add <package>`
+- To remove a package: `pnpm rm <package>`
+- To run a script: `pnpm run <script>`
+- To run a script in all packages that have that script: `pnpm -r run <script>`
+
+`pnpm` has powerful [Filtering](https://pnpm.io/filtering) functionality which
+allows you to restrict commands to a specific subset of packages.
+
+For example, to install a package for the `bot` package, we can run
+`pnpm --filter bot add <package>`
+
+For more information, read the [`pnpm` documentation](https://pnpm.io/).
+
+# High level technical overview
+
+To build `discord-server-info`, we'll need a few separate pieces:
+
+- `bot`
+- `db`
+- `app`
+
+![A diagram showing the bot, db, and app pieces and how they relate to each other](https://dev-to-uploads.s3.amazonaws.com/uploads/articles/9davjf2uj8bz0fcpnkiw.png)
+
+`bot` will be a Discord bot. This bot reads data from the servers it's connected
+to and stores it in our database (`db`).
+
+`db` is a Prisma database that provides an API for storing and accessing server
+data.
+
+`app` is a Next.js application that allows users to authenticate with Discord
+and explore data from their servers.
+
+> If you're wondering why we need this structure rather than having the app read
+> data directly from the Discord API, it's because the Discord API intentionally
+> provides access to very little data. A bot account is required for full
+> access.
+
+The `discord-server-info` repo is a monorepo with a separate package for each
+piece.

--- a/README.md
+++ b/README.md
@@ -22,28 +22,9 @@ You'll have to go through them one-by-one. Good luck!
 Or: you can use `discord-server-info` (once it's built) to generate that list
 for you!
 
-## Technical Overview
+## Contributing
 
-To make this work, `discord-server-info` will need a few separate pieces:
-
-- `bot`
-- `db`
-- `app`
-
-![A diagram showing the bot, db, and app pieces and how the relate](./assets/pieces.png)
-
-`bot` is a Discord bot that reads data from the servers it's connected to and
-stores it in the `db`.
-
-`db` is a Prisma database that provides an API for storing app settings and
-anonymized server data.
-
-`app` is a Next.js application that allows users to authenticate with Discord
-and explore data from their servers.
-
-> If you're wondering why we need this structure rather than having the app read
-> data directly from the Discord API, it's because the Discord API intentionally
-> provides access to very little data. A bot account is required for full
-> access.
-
-This project will eventually be a monorepo with a package for each piece.
+If you'd like to contribute to this project, please begin by reading through
+[`CONTRIBUTING.md`](./CONTRIBUTING.md) for a technical overview of this
+repository and information regarding [`pnpm`](https://pnpm.io/), the package
+manager used in this repository.


### PR DESCRIPTION
This PR creates `CONTRIBUTING.md` which contains:

- details about using `pnpm` for package management
- a high level technical overview of the monorepo

This information will hopefully make it easier for new contributors to get involved and understand the project.

We'll need to remember to update this file as we add contributor-related functionality, like #8 or adding scripts for starting/building/testing our various packages.

This PR also replaces the high level technical overview in `README.md` with a section encouraging contributors to read `CONTRIBUTING.md`.

To view the rendered output of these files, visit [`CONTRIBUTING.md`](https://github.com/Developer-DAO/discord-server-info/blob/contributing.md/CONTRIBUTING.md) and [`README.md`](https://github.com/Developer-DAO/discord-server-info/blob/contributing.md/README.md).